### PR TITLE
Create hive database in postgres upon start up

### DIFF
--- a/postgresscripts/create_hive_table.sql
+++ b/postgresscripts/create_hive_table.sql
@@ -1,0 +1,2 @@
+-- Create a database called 'hive'
+CREATE DATABASE hive;


### PR DESCRIPTION
Add a missing `postgresscripts/create_hive_table.sql` file to create the hive database on startup.

This avoids the following error starting up:

```
metastore_db-1       | 2024-11-24 17:52:17.193 UTC [121] FATAL:  database "hive" does not exist
```